### PR TITLE
Add setter methods for all documented `PayLinkRequest` fields

### DIFF
--- a/src/CityPay/PayLink/Cardholder.php
+++ b/src/CityPay/PayLink/Cardholder.php
@@ -71,13 +71,18 @@ class Cardholder implements \CityPay\Lib\Security\PciDssLoggable {
     }
 
     /**
-     * @param string $title
-     * @return Cardholder
+     * @param string $mobile Any known mobile number of the card holder.
+     * This can be used for:
+     *  - Data collection via the Paylink Payment Form
+     *  - Optionally send an SMS on completion of a transaction. This feature
+     *  is a licensable option and is not configured by default.
+     * 
+     * @return $this
      */
-    public function title(
-        $title
+    public function mobile(
+        $mobile
     ) {
-        self::set("title", $title);
+        self::set("mobile", $mobile);
         return $this;
     }
 
@@ -89,6 +94,17 @@ class Cardholder implements \CityPay\Lib\Security\PciDssLoggable {
         $remoteAddress
     ) {
         self::set("remoteAddr", $remoteAddress);
+        return $this;
+    }
+
+    /**
+     * @param string $title
+     * @return Cardholder
+     */
+    public function title(
+        $title
+    ) {
+        self::set("title", $title);
         return $this;
     }
 

--- a/src/CityPay/PayLink/Configuration.php
+++ b/src/CityPay/PayLink/Configuration.php
@@ -78,6 +78,38 @@ class Configuration
     }
 
     /**
+     * @param string $merchantLogo A URL of a merchant logo to include.
+     * The logo should be delivered over HTTPS and at a max file size of 20kb.
+     * Allowed MIME types being:
+     * - image/gif
+     * - image/png
+     * - image/jpg
+     * - image/jpeg
+     * 
+     * @return $this
+     */
+    public function merchantLogo(
+        $merchantLogo
+    ) {
+        self::set("merch_logo", $merchantLogo);
+        return $this;
+    }
+
+    /**
+     * @param string $merchantTerms A URL of the terms of payment that you wish
+     * to be confirmed. If provided, a link and checkbox will be added that
+     * will be required to be checked before payment may continue.
+     * 
+     * @return $this
+     */
+    public function merchantTerms(
+        $merchantTerms
+    ) {
+        self::set("merch_terms", $merchantTerms);
+        return $this;
+    }
+
+    /**
      * @param string $lockedParams
      * @return Configuration
      */
@@ -129,6 +161,22 @@ class Configuration
         $redirect
     ) {
         self::set("redirect", $redirect);
+        return $this;
+    }
+
+    /**
+     * @param int $redirectDelay The delay (in seconds) before the customers
+     * browser is redirected by the Paylink Payment Form on conclusion of a
+     * successful transaction.
+     * A value of 0 specifies immediate redirection.
+     * Leaving this field unset, or setting it to a negative value, specifies
+     * that no redirection should occur.
+     * @return $this
+     */
+    public function redirectDelay(
+        $redirectDelay
+    ) {
+        self::set("redirect_delay", $redirectDelay);
         return $this;
     }
 

--- a/src/CityPay/PayLink/PayLinkRequest.php
+++ b/src/CityPay/PayLink/PayLinkRequest.php
@@ -74,6 +74,20 @@ class PayLinkRequest
     }
 
     /**
+     * @param string $clientVersion An identifier used to specify the version
+     * of your application that has invoked the Paylink payment process.
+     * 
+     * @return $this
+     */
+    public function clientVersion(
+        $clientVersion
+    )
+    {
+        parent::set("clientVersion", $clientVersion);
+        return $this->this();
+    }
+
+    /**
      * @param \CityPay\PayLink\Configuration $configuration
      * @return \CityPay\PayLink\PayLinkRequest
      */
@@ -94,6 +108,21 @@ class PayLinkRequest
     )
     {
         parent::set("currency", $currencyCode);
+        return $this->this();
+    }
+
+    /**
+     * @param string $email An RFC 5322 compliant email address, used for the
+     * merchant to be notified on completion of the transaction.
+     * The value may be supplied to override the default stored value.
+     * 
+     * @return $this
+     */
+    public function email(
+        $email
+    )
+    {
+        parent::set("email", $email);
         return $this->this();
     }
 

--- a/src/CityPay/PayLink/PayLinkRequest.php
+++ b/src/CityPay/PayLink/PayLinkRequest.php
@@ -25,6 +25,18 @@ class PayLinkRequest
     }
 
     /**
+     * @param $accountNo
+     * @return $this
+     */
+    public function accountNo(
+        $accountNo
+    )
+    {
+        parent::set("accountNo", $accountNo);
+        return $this;
+    }
+
+    /**
      * @param $address
      * @return $this
      */
@@ -130,18 +142,6 @@ class PayLinkRequest
     )
     {
         parent::set("test", $test);
-        return $this->this();
-    }
-
-    /**
-     * @param $accountNo
-     * @return $this
-     */
-    public function accountNo(
-        $accountNo
-    )
-    {
-        parent::set("accountNo", $accountNo);
         return $this->this();
     }
 


### PR DESCRIPTION
Based on the [`PayLinkRequest` API token documentation](https://citypay.com/ps/api-documentation/paylinkv3/token-api-reference.html#4_2) provided, there are a number of  request fields available which this PHP SDK does not facilitate for.

Examples include:
`CityPay\PayLink\PayLinkRequest.php`
- request.clientVersion
- request.email
- request.cart

`CityPay\PayLink\Configuration.php`
- config.merchant_logo
- config.merchhant_terms
- config.redirect_delay

`CityPay\PayLink\Cardholder.php`
- cardholder.mobile

This Pull Request serves to add setter methods for all of the above API token fields (and possibly some others if highlighted).

Any feedback on the suggested changes before I make a start would be appreciated.

(**Note**: initial commit in this PR branch is largely just to have my PR branch pushed up to my forked `CityPay\php-sdk` repository on GitHub for PR creation)